### PR TITLE
feat: cache to avoid hitting cdn rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ chart.save_file()
 Added persistent, on-disk caching for Highcharts JavaScript library downloads to avoid repeated network requests and prevent hitting Highcharts rate limits.
 
 **Key Changes:**
-- Introduced [`diskcache`](https://pypi.org/project/diskcache/) to store downloaded JS files in `./highcharts_cache` (50 MB limit).
+- Introduced [`diskcache`](https://pypi.org/project/diskcache/) to store downloaded JS files in `./.cache/highcharts-excentis` (50 MB limit).
 - Default **time-to-live (TTL)** for cached files: **7 days**.
 - Requests now go through a `get_or_download(url)` helper:
   - **Cache hit** → return stored content.
@@ -611,10 +611,10 @@ Added persistent, on-disk caching for Highcharts JavaScript library downloads to
 
 **What Users Should Know:**
 - First run may download required files; subsequent runs reuse local cache.
-- Cache directory path (`./highcharts_cache`) works with project’s CI/CD and artifact/cache strategy.
+- Cache directory path (`./.cache/highcharts-excentis`) works with project’s CI/CD and artifact/cache strategy.
   this directory is automatically generated in your working directory
 - Prevents repeated HTTP calls between test runs and across pipelines when artifacts/cache are reused.
-- Cache can be cleared manually by deleting `./highcharts_cache`.
+- Cache can be cleared manually by deleting `./.cache/highcharts-excentis`.
 
 ## Todo:
 

--- a/README.md
+++ b/README.md
@@ -596,6 +596,26 @@ chart.save_file()
 
 ```
 
+## 📦 HTTP Request Caching
+
+**Summary:**  
+Added persistent, on-disk caching for Highcharts JavaScript library downloads to avoid repeated network requests and prevent hitting Highcharts rate limits.
+
+**Key Changes:**
+- Introduced [`diskcache`](https://pypi.org/project/diskcache/) to store downloaded JS files in `./highcharts_cache` (50 MB limit).
+- Default **time-to-live (TTL)** for cached files: **7 days**.
+- Requests now go through a `get_or_download(url)` helper:
+  - **Cache hit** → return stored content.
+  - **Cache miss** → download via `urllib.request`, store in cache, return result.
+- Automatic cleanup of expired entries using `cache.cull()`.
+
+**What Users Should Know:**
+- First run may download required files; subsequent runs reuse local cache.
+- Cache directory path (`./highcharts_cache`) works with project’s CI/CD and artifact/cache strategy.
+  this directory is automatically generated in your working directory
+- Prevents repeated HTTP calls between test runs and across pipelines when artifacts/cache are reused.
+- Cache can be cleared manually by deleting `./highcharts_cache`.
+
 ## Todo:
 
 * More examples

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ chart.save_file()
 ## 📦 HTTP Request Caching
 
 **Summary:**  
-Added persistent, on-disk caching for Highcharts JavaScript library downloads to avoid repeated network requests and prevent hitting Highcharts rate limits.
+Added persistent, on-disk caching for Highcharts JavaScript library downloads to avoid repeated network requests and prevent hitting Highcharts CDN rate limits.
 
 **Key Changes:**
 - Introduced [`diskcache`](https://pypi.org/project/diskcache/) to store downloaded JS files in `./.cache/highcharts-excentis` (50 MB limit).

--- a/highcharts_excentis/highcharts/highcharts.py
+++ b/highcharts_excentis/highcharts/highcharts.py
@@ -34,7 +34,7 @@ CONTENT_FILENAME = "content.html"
 PAGE_FILENAME = "page.html"
 
 # 50MB limit, to ensure LRU evection
-_CACHE = dc.Cache('./highcharts_cache', size_limit=50 * 1024**2)
+_CACHE = dc.Cache('./.cache/highcharts-excentis', size_limit=50 * 1024**2)
 
 _CACHE.cull()  # Clean up expired entries
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ maintainers = [
 requires-python = ">=3.4"
 dependencies = [
     'future',
-    'Jinja2', # for templates
+    'diskcache', # to avoid http rate limit
+    'Jinja2' # for templates
 ]
 keywords = [
     'python',


### PR DESCRIPTION
Added persistent, on-disk caching for Highcharts JavaScript library downloads to avoid repeated network requests and prevent hitting Highcharts rate limits

Introduced [diskcache]

First run may download required files; subsequent runs reuse local cache ('./highcharts_cache')

Easy to integrate with pipelines